### PR TITLE
Preliminary support for multi-pass shadertoys.

### DIFF
--- a/glsl2hlsl-wasm/src/lib.rs
+++ b/glsl2hlsl-wasm/src/lib.rs
@@ -1,6 +1,6 @@
 mod utils;
 
-use glsl2hlsl::{get_files, make_shader};
+use glsl2hlsl::{get_files, get_image_files, make_shader, ShaderType};
 use wasm_bindgen::prelude::*;
 
 // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
@@ -12,6 +12,8 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 #[wasm_bindgen(module = "/www/file.js")]
 extern "C" {
     fn download_file(name: &str, contents: &str);
+    fn download_image(name: &str, contents: &str);
+    fn reset();
 }
 
 #[wasm_bindgen]
@@ -22,16 +24,24 @@ extern "C" {
 
 #[wasm_bindgen]
 pub fn transpile(input: String, extract_props: bool, raymarch: bool) -> String {
-    glsl2hlsl::transpile(input, extract_props, raymarch)
+    glsl2hlsl::transpile(input, extract_props, raymarch, ShaderType::MainImage(format!("main"), None, vec![]))
 }
 
 #[wasm_bindgen]
 pub fn download(json: String, extract_props: bool, raymarch: bool) {
     let shader = make_shader(&json).unwrap();
     let files = get_files(&shader, extract_props, raymarch);
+    let images = get_image_files(&shader);
+    reset();
     for f in files.iter() {
         unsafe {
             download_file(&f.name, &f.contents);
         }
     }
+    for f in images.iter() {
+        unsafe {
+            download_image(&f.name, &f.contents);
+        }
+    }
+    
 }

--- a/glsl2hlsl-wasm/www/file.js
+++ b/glsl2hlsl-wasm/www/file.js
@@ -21,3 +21,21 @@ export function download_file(name, contents) {
     document.body.appendChild(a);
     a.click();
 }
+
+export function download_image(name, contents) {
+    
+    const c = document.createElement("br");
+    document.querySelector("#links").appendChild(c);
+    const a = document.createElement("a");
+    a.innerHTML = name;
+    a.href = contents;
+    a.download = name;
+    document.querySelector("#links").appendChild(a);
+    
+    //document.body.appendChild(a);
+    // a.click();
+}
+
+export function reset() {
+    document.querySelector("#links").innerHTML="<p></p><h2>Textures (Ctrl+Click and Save-As):</h2><br>";
+}

--- a/glsl2hlsl-wasm/www/index.html
+++ b/glsl2hlsl-wasm/www/index.html
@@ -44,9 +44,11 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ){
     <input type="checkbox" id="extract"  style="margin-left:10%;"></input>Extract properties (Super experimental, might break)
     <input type="checkbox" id="raymarch"  style="margin-left:10%;"></input>Raymarched (Super experimental, might break)
     <br><br>
-    
+    <div id="links"></div>
+    <br><br>    
     <input id="download" type="button" value="Download from URL or ID">
     <input id="shader" value="https://www.shadertoy.com/view/XsXXDn" style="width:30%"><br>
+    <br><br>
 
     <style>
         * { box-sizing: border-box; }
@@ -75,7 +77,6 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ){
         }
 
     </style>
-
     <script src="./bootstrap.js"></script>
   </body>
 </html>

--- a/src/glsl2hlsl/downloader.rs
+++ b/src/glsl2hlsl/downloader.rs
@@ -1,6 +1,9 @@
 use serde::Deserialize;
 
 use crate::transpile;
+use crate::add_buffer_num;
+use crate::reset_buffer_num;
+use crate::BUFFER_NUM;
 
 #[derive(Deserialize, Debug)]
 #[allow(non_snake_case)]
@@ -23,7 +26,9 @@ struct ShaderInfo {
 struct ShaderRenderPass {
     inputs: Vec<ShaderInput>,
     code: String,
-}
+    name: String,
+    r#type: String,
+}   
 
 #[derive(Deserialize, Debug)]
 struct ShaderInput {
@@ -44,7 +49,16 @@ struct ShaderSampler {
 pub struct ShaderFile {
     pub name: String,
     pub contents: String,
+}  
+
+#[derive(Clone)]
+pub enum ShaderType {
+    MainImage(String, Option<String>, Vec<(usize, String)>),
+    Buffer(usize, String),
+    Common(String)
 }
+
+
 
 pub fn download_shader(id: &str) -> Result<Shader, ureq::Error> {
     let url = format!("https://www.shadertoy.com/api/v1/shaders/{}?key=NtHtMm", id);
@@ -65,11 +79,55 @@ fn generate_guid(shader: &Shader) -> String {
     res
 }
 
-fn get_shader_file(shader: &Shader, extract_props: bool, raymarch: bool) -> ShaderFile {
-    ShaderFile {
+// fn get_shader_file(shader: &Shader, extract_props: bool, raymarch: bool) -> ShaderFile {
+//     ShaderFile {
+//         name: format!("{}.shader", shader.info.name.clone()),
+//         contents: transpile(shader.renderpass[0].code.clone(), extract_props, raymarch),
+//     }
+// }
+
+
+pub fn get_common(shader: &Shader) -> Option<String> {
+    shader.renderpass.iter()
+    .find(|ri| ri.r#type == "common")
+    .map(|rp| transpile(rp.code.clone(), false, false, ShaderType::Common(format!("{}{}",shader.info.name.clone(), rp.name.clone()))))
+}
+
+pub fn get_buffers(shader: &Shader) -> Vec<(usize, String)> {
+    shader.renderpass.iter()
+    .filter(|ri| ri.r#type == "buffer")
+    .map(|rp| {
+            let mm = (unsafe{BUFFER_NUM},transpile(rp.code.clone(), false, false, ShaderType::Buffer(unsafe {BUFFER_NUM}, rp.name.clone())));
+            add_buffer_num();
+            mm
+        }
+    )
+    .collect()
+}
+
+pub fn get_shader_file(shader: &Shader, extract_props: bool, raymarch: bool, common: Option<String>, buffers: Vec<(usize, String)>) -> Vec<ShaderFile> {
+    shader.renderpass.iter()
+    .filter(|ri| ri.r#type == "image")
+    .map(|rp| ShaderFile {
         name: format!("{}.shader", shader.info.name.clone()),
-        contents: transpile(shader.renderpass[0].code.clone(), extract_props, raymarch),
-    }
+        contents: transpile(rp.code.clone(), extract_props, raymarch, ShaderType::MainImage(format!("{}{}",shader.info.name.clone(), rp.name.clone()),common.clone(), buffers.clone()))
+    })
+    .collect()
+}
+
+//Need to verify that this works first.
+pub fn get_image_files(shader: &Shader) -> Vec<ShaderFile> {
+    //TODO: Set up cors proxy for images.
+    shader.renderpass.iter().flat_map(|rp| {
+        rp.inputs.iter()
+        .filter(|inp| inp.ctype == "texture")
+        .map(|inp| ShaderFile {
+            name: format!("iChannel{} {}.{}",  rp.name, inp.channel, inp.src.chars().skip_while(|&c| c != '.').collect::<String>()),
+            contents: format!("https://www.shadertoy.com{}", inp.src),
+        })
+        .collect::<Vec<_>>()
+    })
+    .collect()     
 }
 
 pub fn get_shader_meta_file(shader: &Shader, guid: &String) -> ShaderFile {
@@ -93,19 +151,30 @@ ShaderImporter:
     }
 }
 
-fn get_image_files(shader: &Shader) -> Vec<ShaderFile> {
-    shader.renderpass[0]
-        .inputs
-        .iter()
-        .filter(|inp| inp.ctype == "texture")
-        .map(|inp| ShaderFile {
-            name: format!("iChannel{}.png", inp.channel),
-            contents: format!("shadertoy.com{}", inp.src),
-        })
-        .collect()
+pub fn get_mat_meta_file(name: &String, guid: &String) -> ShaderFile {
+    let content = format!(
+        "fileFormatVersion: 2
+guid: {}
+ShaderImporter:
+    externalObjects: {{}}
+    defaultTextures: []
+    nonModifiableTextures: []
+    userData: 
+    assetBundleName: 
+    assetBundleVariant: 
+    ",
+        guid
+    );
+
+    ShaderFile {
+        name: format!("{}.mat.meta", name.clone()),
+        contents: content,
+    }
 }
 
-fn get_material_file(shader: &Shader, shader_guid: &String) -> ShaderFile {
+
+
+fn get_material_file(name: &String, shader_guid: &String, buffers: Vec<(usize, String)> ) -> ShaderFile {
     let content = format!(
         "%YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
@@ -128,22 +197,23 @@ Material:
   m_SavedProperties:
     serializedVersion: 0
     m_TexEnvs:
-    - _MainTex:
+    - _MainTex_0:
         m_Texture: {{fileID: 0}}
         m_Scale: {{x: 1, y: 1}}
         m_Offset: {{x: 0, y: 0}}
-    - _SecondTex:
+    - _SecondTex_0:
         m_Texture: {{fileID: 0}}
         m_Scale: {{x: 1, y: 1}}
         m_Offset: {{x: 0, y: 0}}
-    - _ThirdTex:
+    - _ThirdTex_0:
         m_Texture: {{fileID: 0}}
         m_Scale: {{x: 1, y: 1}}
         m_Offset: {{x: 0, y: 0}}
-    - _FourthTex:
+    - _FourthTex_0:
         m_Texture: {{fileID: 0}}
         m_Scale: {{x: 1, y: 1}}
         m_Offset: {{x: 0, y: 0}}
+    {}
     m_Floats:
     - _DstBlend: 0
     - _Mode: 0
@@ -153,21 +223,192 @@ Material:
     m_Colors:
     - _Mouse: {{r: 0.5, g: 0.5, b: 0.5, a: 0.5}}
 ",
-        shader_guid
+        shader_guid,
+        buffers.iter().map(
+            |(i,_)| format!("- _MainTex_{}:
+        m_Texture: {{fileID: 0}}
+        m_Scale: {{x: 1, y: 1}}
+        m_Offset: {{x: 0, y: 0}}
+    - _SecondTex_{}:
+        m_Texture: {{fileID: 0}}
+        m_Scale: {{x: 1, y: 1}}
+        m_Offset: {{x: 0, y: 0}}
+    - _ThirdTex_{}:
+        m_Texture: {{fileID: 0}}
+        m_Scale: {{x: 1, y: 1}}
+        m_Offset: {{x: 0, y: 0}}
+    - _FourthTex_{}:
+        m_Texture: {{fileID: 0}}
+        m_Scale: {{x: 1, y: 1}}
+        m_Offset: {{x: 0, y: 0}}", i, i, i, i
+            )
+        )
+        .collect::<Vec<_>>()
+        .concat()
     );
 
     ShaderFile {
-        name: format!("{}.mat", shader.info.name.clone()),
+        name: format!("{}.mat", name),
         contents: content,
     }
 }
 
+
+fn get_crt_file(shader_name: &String, shader_guid: &String, id: &usize) -> ShaderFile {
+    let content = format!(
+"%YAML 1.1  
+%TAG !u! tag:unity3d.com,2011:
+--- !u!86 &8600000
+CustomRenderTexture:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {{fileID: 0}}
+  m_PrefabInstance: {{fileID: 0}}
+  m_PrefabAsset: {{fileID: 0}}
+  m_Name: Buffer {} CRT
+  m_ImageContentsHash:
+    serializedVersion: 2
+    Hash: 00000000000000000000000000000000
+  m_ForcedFallbackFormat: 4
+  m_DownscaleFallback: 0
+  serializedVersion: 3
+  m_Width: 800
+  m_Height: 450
+  m_AntiAliasing: 1
+  m_MipCount: -1
+  m_DepthFormat: 0
+  m_ColorFormat: 52
+  m_MipMap: 0
+  m_GenerateMips: 1
+  m_SRGB: 0
+  m_UseDynamicScale: 0
+  m_BindMS: 0
+  m_EnableCompatibleFormat: 1
+  m_TextureSettings:
+    serializedVersion: 2
+    m_FilterMode: 0
+    m_Aniso: 1
+    m_MipBias: 0
+    m_WrapU: 1
+    m_WrapV: 1
+    m_WrapW: 1
+  m_Dimension: 2
+  m_VolumeDepth: 1
+  m_Material: {{fileID: 2100000, guid: {}, type: 2}}
+  m_InitSource: 0
+  m_InitMaterial: {{fileID: 0}}
+  m_InitColor: {{r: 1, g: 1, b: 1, a: 1}}
+  m_InitTexture: {{fileID: 0}}
+  m_UpdateMode: 1
+  m_InitializationMode: 2
+  m_UpdateZoneSpace: 0
+  m_CurrentUpdateZoneSpace: 0
+  m_UpdateZones:
+  - updateZoneCenter: {{x: 0.5, y: 0.5, z: 0.5}}
+    updateZoneSize: {{x: 1, y: 1, z: 1}}
+    rotation: 0
+    passIndex: -1
+    needSwap: 1
+  - updateZoneCenter: {{x: 0.5, y: 0.5, z: 0.5}}
+    updateZoneSize: {{x: 1, y: 1, z: 1}}
+    rotation: 0
+    passIndex: -1
+    needSwap: 1
+  - updateZoneCenter: {{x: 0.5, y: 0.5, z: 0.5}}
+    updateZoneSize: {{x: 1, y: 1, z: 1}}
+    rotation: 0
+    passIndex: -1
+    needSwap: 1
+  - updateZoneCenter: {{x: 0.5, y: 0.5, z: 0.5}}
+    updateZoneSize: {{x: 1, y: 1, z: 1}}
+    rotation: 0
+    passIndex: -1
+    needSwap: 1
+  - updateZoneCenter: {{x: 0.5, y: 0.5, z: 0.5}}
+    updateZoneSize: {{x: 1, y: 1, z: 1}}
+    rotation: 0
+    passIndex: -1
+    needSwap: 1
+  - updateZoneCenter: {{x: 0.5, y: 0.5, z: 0.5}}
+    updateZoneSize: {{x: 1, y: 1, z: 1}}
+    rotation: 0
+    passIndex: -1
+    needSwap: 1
+  - updateZoneCenter: {{x: 0.5, y: 0.5, z: 0.5}}
+    updateZoneSize: {{x: 1, y: 1, z: 1}}
+    rotation: 0
+    passIndex: -1
+    needSwap: 1
+  - updateZoneCenter: {{x: 0.5, y: 0.5, z: 0.5}}
+    updateZoneSize: {{x: 1, y: 1, z: 1}}
+    rotation: 0
+    passIndex: -1
+    needSwap: 1
+  - updateZoneCenter: {{x: 0.5, y: 0.5, z: 0.5}}
+    updateZoneSize: {{x: 1, y: 1, z: 1}}
+    rotation: 0
+    passIndex: -1
+    needSwap: 1
+  - updateZoneCenter: {{x: 0.5, y: 0.5, z: 0.5}}
+    updateZoneSize: {{x: 1, y: 1, z: 1}}
+    rotation: 0
+    passIndex: -1
+    needSwap: 1
+  - updateZoneCenter: {{x: 0.5, y: 0.5, z: 0.5}}
+    updateZoneSize: {{x: 1, y: 1, z: 1}}
+    rotation: 0
+    passIndex: -1
+    needSwap: 1
+  - updateZoneCenter: {{x: 0.5, y: 0.5, z: 0.5}}
+    updateZoneSize: {{x: 1, y: 1, z: 1}}
+    rotation: 0
+    passIndex: -1
+    needSwap: 1
+  - updateZoneCenter: {{x: 0.5, y: 0.5, z: 0.5}}
+    updateZoneSize: {{x: 1, y: 1, z: 1}}
+    rotation: 0
+    passIndex: -1
+    needSwap: 1
+  m_UpdatePeriod: 0
+  m_ShaderPass: {}
+  m_CubemapFaceMask: 4294967295
+  m_DoubleBuffered: 1
+  m_WrapUpdateZones: 0
+",      id,  
+        shader_guid,
+        id
+    );
+
+    ShaderFile {
+        name: format!("buffer{}_{}.asset", shader_name, id),
+        contents: content,
+    }
+}
+
+pub fn test_file(shader: &Shader, extract_props: bool, raymarch: bool) -> Vec<(usize, String)> {
+    get_buffers(shader)
+
+}
+
+
 pub fn get_files(shader: &Shader, extract_props: bool, raymarch: bool) -> Vec<ShaderFile> {
     let shader_guid = generate_guid(shader);
-    let shader_file = get_shader_file(shader, extract_props, raymarch);
-    let shader_meta_file = get_shader_meta_file(shader, &shader_guid);
-
-    let mat_file = get_material_file(shader, &shader_guid);
-
-    vec![shader_file, shader_meta_file, mat_file]
+    reset_buffer_num();
+    add_buffer_num();
+    let common = get_common(shader);
+    let buffers = get_buffers(shader);
+    reset_buffer_num();
+    let mut shader_files = get_shader_file(shader, extract_props, raymarch, common, buffers.clone());
+    let shader_meta_file = get_shader_meta_file(shader, &shader_guid.clone());
+    let mat_file = get_material_file(&shader.info.name.clone(), &shader_guid.clone(), buffers.clone());
+    let mut other_mat_files : Vec<ShaderFile> = buffers.iter()
+                            .map(|(n, _)| get_material_file(&format!("{} Buffer{}", shader.info.name.clone(),n),&shader_guid.clone(), buffers.clone()))
+                            .collect();
+    let mut crt_files : Vec<ShaderFile> = buffers.iter()
+                            .map(|(n, _)| get_crt_file(&shader.info.name.clone(),&shader_guid.clone(), n))
+                            .collect();
+    let mut other_files = vec![shader_meta_file, mat_file];
+    shader_files.append(&mut other_files);
+    shader_files.append(&mut crt_files);
+    shader_files.append(&mut other_mat_files);
+    shader_files
 }

--- a/src/glsl2hlsl/transpiler.rs
+++ b/src/glsl2hlsl/transpiler.rs
@@ -6,13 +6,15 @@ use glsl::syntax::*;
 
 use super::preprocessor::*;
 use super::typechecker::*;
+use super::downloader::ShaderType;
 
-pub fn transpile(input: String, extract_props: bool, raymarch: bool) -> String {
+
+pub fn transpile(input: String, extract_props: bool, raymarch: bool, option: ShaderType) -> String {
     clear_sym();
-
     // Preprocessor step
+    
     let (glsl, defs, mut props) = process_macros(input, extract_props);
-
+    
     let mut stage = ShaderStage::parse(glsl);
     match &mut stage {
         Err(a) => a.info.clone(),
@@ -21,11 +23,21 @@ pub fn transpile(input: String, extract_props: bool, raymarch: bool) -> String {
             props.append(&mut globals);
 
             let mut s = String::new();
-            if raymarch {
-                show_translation_unit_raymarch(&mut s, &stage, props);
-            } else {
-                show_translation_unit(&mut s, &stage, props);
+            match &option{
+                ShaderType::MainImage(title,common,buffers) => {
+                    if raymarch {
+                        show_translation_unit_raymarch(&mut s, &stage, props,title.clone(),common.clone(),buffers.clone());
+                    } else {
+                        show_translation_unit(&mut s, &stage, props, title.clone(),common.clone(),buffers.clone());
+                    }
+                },
+                ShaderType::Buffer(id, _) => {
+                    show_translation_unit_buffer(&mut s, &stage, props, id.clone())
+                },
+                ShaderType::Common(_) => show_translation_unit_common(&mut s, &stage, props),
+                _ => panic!() 
             }
+
             replace_macros(s, defs)
         }
     }
@@ -33,6 +45,41 @@ pub fn transpile(input: String, extract_props: bool, raymarch: bool) -> String {
 
 // I'm gonna burn in hell for this
 static mut INDENT_LEVEL: usize = 3;
+// Me too
+pub static mut BUFFER_NUM: usize = 0;
+// fn set_buffer_num(i: i32) {
+//     unsafe {
+//         match i {
+//             0 => BUFFER_NUM = "_0", 
+//             1 => BUFFER_NUM = "_1",
+//             2 => BUFFER_NUM = "_2",
+//             _ => BUFFER_NUM = "",
+//         }
+//     }
+// }
+
+fn get_buffer_num(text : String) -> String {
+   unsafe { match 
+        BUFFER_NUM {
+            1 => format!("{}_1",text),
+            2 => format!("{}_2",text),
+            3 => format!("{}_3",text),
+            4 => format!("{}_4",text),
+            _ => "idk".to_string(),
+        }
+    } 
+}
+
+pub fn add_buffer_num() {
+    unsafe {
+        BUFFER_NUM += 1;
+    }
+}
+pub fn reset_buffer_num() {
+    unsafe {
+        BUFFER_NUM = 0;
+    }
+}
 fn add_indent() {
     unsafe {
         INDENT_LEVEL += 1;
@@ -107,14 +154,46 @@ fn show_identifier<F>(f: &mut F, i: &Identifier)
 where
     F: Write,
 {
+    let mut s = String::new();
+
     let rep = match i.0.as_str() {
         "iTime" => "_Time.y",
         "iTimeDelta" => "unity_DeltaTime.x",
-        "iChannel0" => "_MainTex",
-        "iChannel1" => "_SecondTex",
-        "iChannel2" => "_ThirdTex",
-        "iChannel3" => "_FourthTex",
-        "gl_FragCoord" => "(vertex_output.uv * _Resolution)",
+        "iChannel0" => {
+            match unsafe{BUFFER_NUM} {
+                1..=4 => write!(s, "_MainTex_{}", unsafe{BUFFER_NUM}).unwrap(),
+                _ =>  write!(s, "_MainTex").unwrap()
+            }
+            s.as_str()
+        },
+        "iChannel1" => {
+            match unsafe{BUFFER_NUM} {
+                1..=4 => write!(s, "_SecondTex_{}", unsafe{BUFFER_NUM}).unwrap(),
+                _ =>  write!(s, "_SecondTex").unwrap()
+            }
+            s.as_str()
+        },
+        "iChannel2" => {
+            match unsafe{BUFFER_NUM} {
+                1..=4 => write!(s, "_ThirdTex_{}", unsafe{BUFFER_NUM}).unwrap(),
+                _ =>  write!(s, "_ThirdTex").unwrap()
+            }
+            s.as_str()
+        },
+        "iChannel3" => {
+            match unsafe{BUFFER_NUM} {
+                1..=4 => write!(s, "_FourthTex_{}", unsafe{BUFFER_NUM}).unwrap(),
+                _ =>  write!(s, "_FourthTex").unwrap()
+            }       
+            s.as_str()
+        },
+        "gl_FragCoord" => {
+            match unsafe{BUFFER_NUM} {
+                1..=4 => write!(s, "(vertex_output_{}.globalTexcoord.xy * _Resolution)", unsafe{BUFFER_NUM}).unwrap(),
+                _ =>  write!(s, "(vertex_output_{}.uv * _Resolution)", unsafe{BUFFER_NUM}).unwrap()
+            }
+            s.as_str()
+        },
         "iMouse" => "_Mouse",
 
         //iResolution, iFrame, iChannelTime, iChannelResolution, iMouse, iDate, iSampleRate
@@ -1857,23 +1936,43 @@ where
     }
 }
 
-fn show_translation_unit<F>(f: &mut F, tu: &TranslationUnit, props: Vec<ShaderProp>)
+fn show_translation_unit<F>(f: &mut F, tu: &TranslationUnit, props: Vec<ShaderProp>, title: String, common: Option<String>, buffers: Vec<(usize, String)>)
 where
     F: Write,
 {
+           
+    let _ = f.write_str(&format!(r#"Shader "Converted/{}""#,title).to_string());
     let _ = f.write_str(
-        "Shader \"Converted/Template\"
+        "
 {
     Properties
     {
+        [Header(General)]
         _MainTex (\"iChannel0\", 2D) = \"white\" {}
         _SecondTex (\"iChannel1\", 2D) = \"white\" {}
         _ThirdTex (\"iChannel2\", 2D) = \"white\" {}
-        _FourthTex (\"iChannel3\", 2D) = \"white\" {}
+        _FourthTex (\"iChannel3\", 2D) = \"white\" {}\n");
+
+        let m = buffers.iter()
+        .map(|(i, _)| format!("\n
+            _MainTex_{} (\"Buffer {} iChannel0\", 2D) = \"white\" {{}}
+            _SecondTex_{} (\"Buffer {} iChannel1\", 2D) = \"white\" {{}}
+            _ThirdTex_{} (\"Buffer {} iChannel2\", 2D) = \"white\" {{}}
+            _FourthTex_{} (\"Buffer {} iChannel3\", 2D) = \"white\" {{}}\n",i,i,i,i,i,i,i,i
+            ))
+        .collect::<Vec<_>>()
+        .concat();
+            
+        let _ = f.write_str(&m);
+
+        let _ = f.write_str("
         _Mouse (\"Mouse\", Vector) = (0.5, 0.5, 0.5, 0.5)
         [ToggleUI] _GammaCorrect (\"Gamma Correction\", Float) = 1
         _Resolution (\"Resolution (Change if AA is bad)\", Range(1, 1024)) = 1",
     );
+
+
+    
 
     // Add props
     if props.len() > 0 {
@@ -1890,9 +1989,76 @@ where
         }
     }
 
-    let _ = f.write_str("\n    }
+    let _ = f.write_str("\n    }");
+
+    if let Some(comman) = common {
+        let _ = f.write_str(comman.as_str());
+    }
+
+    let _ = f.write_str("
     SubShader
     {
+");
+
+    let m = buffers.iter()
+    .map( 
+        |(i, b)| format!("\n
+        Pass 
+            {{
+                Name \"{}\"
+
+                CGPROGRAM
+                #include \"UnityCustomRenderTexture.cginc\"
+                #pragma target 5.0
+                #pragma vertex CustomRenderTextureVertexShader
+                #pragma fragment frag  
+        
+                #include \"UnityCG.cginc\"
+                // Built-in properties
+                sampler2D _MainTex_{};   float4 _MainTex_{}_TexelSize;
+                sampler2D _SecondTex_{}; float4 _SecondTex_{}_TexelSize;
+                sampler2D _ThirdTex_{};  float4 _ThirdTex_{}_TexelSize;
+                sampler2D _FourthTex_{}; float4 _FourthTex_{}_TexelSize;                
+                float4 _Mouse;
+                float _GammaCorrect;
+                float _Resolution;
+                float _WorldSpace;
+                float4 _Offset;
+
+                //Def CRT Res
+                #ifdef iResolution
+                    #undef iResolution
+                    #define iResolution float3(_CustomRenderTextureWidth, _CustomRenderTextureHeight, _Resolution)
+                #endif
+                // GLSL Compatability macros
+                #ifndef COMMAN_INCLUDE_BLOCK
+                #define COMMAN_INCLUDE_BLOCK
+                    #define glsl_mod(x,y) (((x)-(y)*floor((x)/(y))))
+                    #define texelFetch(ch, uv, lod) tex2Dlod(ch, float4((uv).xy * ch##_TexelSize.xy + ch##_TexelSize.xy * 0.5, 0, lod))
+                    #define textureLod(ch, uv, lod) tex2Dlod(ch, float4(uv, 0, lod))
+                    #define iResolution float3(_CustomRenderTextureWidth, _CustomRenderTextureHeight, _Resolution)
+                    #define iFrame (floor(_Time.y / 60))
+                    #define iChannelTime float4(_Time.y, _Time.y, _Time.y, _Time.y)
+                    #define iDate float4(2020, 6, 18, 30)
+                    #define iSampleRate (44100)
+                #endif    
+                #define iChannelResolution float4x4(                      \\
+                    _MainTex_{}_TexelSize.z,   _MainTex_{}_TexelSize.w,   0, 0, \\
+                    _SecondTex_{}_TexelSize.z, _SecondTex_{}_TexelSize.w, 0, 0, \\
+                    _ThirdTex_{}_TexelSize.z,  _ThirdTex_{}_TexelSize.w,  0, 0, \\
+                    _FourthTex_{}_TexelSize.z, _FourthTex_{}_TexelSize.w, 0, 0)                
+                {}
+                ENDCG
+            }}        
+            ", i,i,i,i,i,i,i,i,i,i,i,i,i,i,i,i,i,b))
+    .collect::<Vec<_>>()
+    .concat();
+    
+    
+    let _ = f.write_str(m.as_str());
+
+
+    let _ = f.write_str("
         Pass
         {
             CGPROGRAM
@@ -1917,11 +2083,17 @@ where
             sampler2D _MainTex;   float4 _MainTex_TexelSize;
             sampler2D _SecondTex; float4 _SecondTex_TexelSize;
             sampler2D _ThirdTex;  float4 _ThirdTex_TexelSize;
-            sampler2D _FourthTex; float4 _FourthTex_TexelSize;
+            sampler2D _FourthTex; float4 _FourthTex_TexelSize;");
+
+            let _ = f.write_str("\n
             float4 _Mouse;
             float _GammaCorrect;
             float _Resolution;
-
+            //Undef CRT Res
+            #ifdef iResolution
+                #undef iResolution
+                #define iResolution float3(_Resolution, _Resolution, _Resolution)
+            #endif
             // GLSL Compatability macros
             #define glsl_mod(x,y) (((x)-(y)*floor((x)/(y))))
             #define texelFetch(ch, uv, lod) tex2Dlod(ch, float4((uv).xy * ch##_TexelSize.xy + ch##_TexelSize.xy * 0.5, 0, lod))
@@ -2007,12 +2179,111 @@ where
     );
 }
 
-fn show_translation_unit_raymarch<F>(f: &mut F, tu: &TranslationUnit, props: Vec<ShaderProp>)
+
+
+fn show_translation_unit_common<F>(f: &mut F, tu: &TranslationUnit, props: Vec<ShaderProp>)
+where
+    F: Write,
+{       
+    let _ = f.write_str(
+        "        CGINCLUDE\n",
+    );
+
+    let _ = f.write_str("
+    #ifndef COMMAN_INCLUDE_BLOCK
+    #define COMMAN_INCLUDE_BLOCK
+        #define glsl_mod(x,y) (((x)-(y)*floor((x)/(y))))
+        #define texelFetch(ch, uv, lod) tex2Dlod(ch, float4((uv).xy * ch##_TexelSize.xy + ch##_TexelSize.xy * 0.5, 0, lod))
+        #define textureLod(ch, uv, lod) tex2Dlod(ch, float4(uv, 0, lod))
+        #define iResolution float3(_Resolution, _Resolution, _Resolution)
+        #define iFrame (floor(_Time.y / 60))
+        #define iChannelTime float4(_Time.y, _Time.y, _Time.y, _Time.y)
+        #define iDate float4(2020, 6, 18, 30)
+        #define iSampleRate (44100)
+    #endif       
+    ");
+    for ed in &(tu.0).0 {
+        match ed {
+            ExternalDeclaration::FunctionDefinition(fdef) => {
+
+                    show_external_declaration(f, ed, &props);
+
+            }
+            _ => show_external_declaration(f, ed, &props),
+        };
+    }
+
+    let _ = f.write_str(
+        "        ENDCG",
+    );
+}
+
+fn show_translation_unit_buffer<F>(f: &mut F, tu: &TranslationUnit, props: Vec<ShaderProp>, bufferId: usize)
+where
+    F: Write,
+{       
+    //ayyyy lmao??
+    let _ = f.write_str(&format!("static v2f_customrendertexture vertex_output_{};\n", bufferId).clone());
+    
+    for ed in &(tu.0).0 {
+        match ed {
+            ExternalDeclaration::FunctionDefinition(fdef) => {
+                if fdef.prototype.name.0.as_str() == "mainImage" {
+                    push_sym();
+
+                    let frag = match &fdef.prototype.parameters[0] {
+                        FunctionParameterDeclaration::Named(_, name) => name.ident.ident.0.as_str(),
+                        _ => panic!(),
+                    };
+                    let uv = match &fdef.prototype.parameters[1] {
+                        FunctionParameterDeclaration::Named(_, name) => name.ident.ident.0.as_str(),
+                        _ => panic!(),
+                    };
+
+                    let _ = f.write_str(get_indent().as_str());
+                    let _ = f.write_str("float4 frag (v2f_customrendertexture __vertex_output) : SV_Target\n");
+                    let _ = f.write_str(get_indent().as_str());
+                    let _ = f.write_str("{\n");
+                    add_indent();
+                    let _ = f.write_str(get_indent().as_str());
+                    
+                    let _ = f.write_str(&format!("vertex_output_{}", bufferId).clone());
+                    let _ = f.write_str(" = __vertex_output;\n");
+                    let _ = f.write_str(get_indent().as_str());
+                    let _ = f.write_fmt(format_args!("float4 {} = 0;\n", frag));
+                    let _ = f.write_str(get_indent().as_str());
+                        
+                    let _ = f.write_fmt(format_args!("float2 {} = vertex_output_{}.globalTexcoord.xy * iResolution.xy;\n", uv, bufferId));
+                    for st in &fdef.statement.statement_list {
+                        show_statement(f, st, true);
+                    }
+                    let _ = f.write_str(get_indent().as_str());
+                    let _ = f.write_str(get_indent().as_str());
+                    let _ = f.write_fmt(format_args!("return {};\n", frag));
+                    sub_indent();
+                    let _ = f.write_str(get_indent().as_str());
+                    let _ = f.write_str("}\n");
+                    
+                    pop_sym();
+                } else {
+                    show_external_declaration(f, ed, &props);
+                }
+            }
+            _ => show_external_declaration(f, ed, &props),
+        };
+    }
+    
+}
+
+
+//crt shader needs another translation unit
+fn show_translation_unit_raymarch<F>(f: &mut F, tu: &TranslationUnit, props: Vec<ShaderProp>, title: String, common: Option<String>, buffers: Vec<(usize, String)>)
 where
     F: Write,
 {
+    let _ = f.write_str(&format!(r#"Shader "Converted/{}""#,title).to_string());
     let _ = f.write_str(
-        "Shader \"Converted/Template\"
+        "
 {
     Properties
     {
@@ -2020,8 +2291,21 @@ where
         _MainTex (\"iChannel0\", 2D) = \"white\" {}
         _SecondTex (\"iChannel1\", 2D) = \"white\" {}
         _ThirdTex (\"iChannel2\", 2D) = \"white\" {}
-        _FourthTex (\"iChannel3\", 2D) = \"white\" {}
-        _Mouse (\"Mouse\", Vector) = (0.5, 0.5, 0.5, 0.5)
+        _FourthTex (\"iChannel3\", 2D) = \"white\" {}");
+
+        let m = buffers.iter()
+        .map(|(i, _)| format!("\n
+            _MainTex_{} (\"Buffer {} iChannel0\", 2D) = \"white\" {{}}
+            _SecondTex_{} (\"Buffer {} iChannel1\", 2D) = \"white\" {{}}
+            _ThirdTex_{} (\"Buffer {} iChannel2\", 2D) = \"white\" {{}}
+            _FourthTex_{} (\"Buffer {} iChannel3\", 2D) = \"white\" {{}}\n",i,i,i,i,i,i,i,i
+            ))
+        .collect::<Vec<_>>()
+        .concat();
+            
+        let _ = f.write_str(&m);
+
+        let _ = f.write_str("_Mouse (\"Mouse\", Vector) = (0.5, 0.5, 0.5, 0.5)
         [ToggleUI] _GammaCorrect (\"Gamma Correction\", Float) = 1
         _Resolution (\"Resolution (Change if AA is bad)\", Range(1, 1024)) = 1
 
@@ -2044,12 +2328,77 @@ where
             ));
         }
     }
+    let _ = f.write_str("\n    }");
 
-    let _ = f.write_str("\n    }
+    if let Some(comman) = common {
+        let _ = f.write_str(comman.as_str());
+    }
+    let _ = f.write_str("
     SubShader
     {
+");
+    let m = buffers.iter()
+    .map( 
+        |(i, b)| format!("\n
+            Pass 
+            {{
+                Name:{}
+                CGPROGRAM
+                #include \"UnityCustomRenderTexture.cginc\"
+                #pragma target 5.0
+                #pragma vertex CustomRenderTextureVertexShader
+                #pragma fragment frag  
+        
+                #include \"UnityCG.cginc\"
+                // Built-in properties
+                sampler2D _MainTex_{};   float4 _MainTex_{}_TexelSize;
+                sampler2D _SecondTex_{}; float4 _SecondTex_{}_TexelSize;
+                sampler2D _ThirdTex_{};  float4 _ThirdTex_{}_TexelSize;
+                sampler2D _FourthTex_{}; float4 _FourthTex_{}_TexelSize;                
+                float4 _Mouse;
+                float _GammaCorrect;
+                float _Resolution;
+                float _WorldSpace;
+                float4 _Offset;
+
+                //CRT Res
+                #ifdef iResolution
+                    #undef iResolution
+                    #define iResolution float3(_CustomRenderTextureWidth, _CustomRenderTextureHeight, _Resolution)
+                #endif
+                // GLSL Compatability macros   
+                #ifndef COMMAN_INCLUDE_BLOCK
+                #define COMMAN_INCLUDE_BLOCK
+                    #define glsl_mod(x,y) (((x)-(y)*floor((x)/(y))))
+                    #define texelFetch(ch, uv, lod) tex2Dlod(ch, float4((uv).xy * ch##_TexelSize.xy + ch##_TexelSize.xy * 0.5, 0, lod))
+                    #define textureLod(ch, uv, lod) tex2Dlod(ch, float4(uv, 0, lod))
+                    #define iResolution float3(_CustomRenderTextureWidth, _CustomRenderTextureHeight, _Resolution)
+                    #define iFrame (floor(_Time.y / 60))
+                    #define iChannelTime float4(_Time.y, _Time.y, _Time.y, _Time.y)
+                    #define iDate float4(2020, 6, 18, 30)
+                    #define iSampleRate (44100)
+                #endif            
+
+                #define iChannelResolution float4x4(                      \\
+                    _MainTex_{}_TexelSize.z,   _MainTex_{}_TexelSize.w,   0, 0, \\
+                    _SecondTex_{}_TexelSize.z, _SecondTex_{}_TexelSize.w, 0, 0, \\
+                    _ThirdTex_{}_TexelSize.z,  _ThirdTex_{}_TexelSize.w,  0, 0, \\
+                    _FourthTex_{}_TexelSize.z, _FourthTex_{}_TexelSize.w, 0, 0)                
+                {}
+                ENDCG
+            }}        
+            ", i,i,i,i,i,i,i,i,i,i,i,i,i,i,i,i,i,b))
+    .collect::<Vec<_>>()
+    .concat();
+    
+    
+    let _ = f.write_str(m.as_str());
+
+
+    let _ = f.write_str("
         Pass
         {
+            Name \"MainImage\"
             Cull Off
 
             CGPROGRAM
@@ -2076,22 +2425,27 @@ where
             sampler2D _MainTex;   float4 _MainTex_TexelSize;
             sampler2D _SecondTex; float4 _SecondTex_TexelSize;
             sampler2D _ThirdTex;  float4 _ThirdTex_TexelSize;
-            sampler2D _FourthTex; float4 _FourthTex_TexelSize;
+            sampler2D _FourthTex; float4 _FourthTex_TexelSize;");
+
+            let _ = f.write_str("\n
             float4 _Mouse;
             float _GammaCorrect;
             float _Resolution;
             float _WorldSpace;
             float4 _Offset;
 
-            // GLSL Compatability macros
-            #define glsl_mod(x,y) (((x)-(y)*floor((x)/(y))))
-            #define texelFetch(ch, uv, lod) tex2Dlod(ch, float4((uv).xy * ch##_TexelSize.xy + ch##_TexelSize.xy * 0.5, 0, lod))
-            #define textureLod(ch, uv, lod) tex2Dlod(ch, float4(uv, 0, lod))
-            #define iResolution float3(_Resolution, _Resolution, _Resolution)
-            #define iFrame (floor(_Time.y / 60))
-            #define iChannelTime float4(_Time.y, _Time.y, _Time.y, _Time.y)
-            #define iDate float4(2020, 6, 18, 30)
-            #define iSampleRate (44100)
+            // GLSL Compatability macros   
+            #ifndef COMMAN_INCLUDE_BLOCK
+            #define COMMAN_INCLUDE_BLOCK
+                #define glsl_mod(x,y) (((x)-(y)*floor((x)/(y))))
+                #define texelFetch(ch, uv, lod) tex2Dlod(ch, float4((uv).xy * ch##_TexelSize.xy + ch##_TexelSize.xy * 0.5, 0, lod))
+                #define textureLod(ch, uv, lod) tex2Dlod(ch, float4(uv, 0, lod))
+                #define iResolution float3(_Resolution, _Resolution, _Resolution)
+                #define iFrame (floor(_Time.y / 60))
+                #define iChannelTime float4(_Time.y, _Time.y, _Time.y, _Time.y)
+                #define iDate float4(2020, 6, 18, 30)
+                #define iSampleRate (44100)
+            #endif    
             #define iChannelResolution float4x4(                      \\
                 _MainTex_TexelSize.z,   _MainTex_TexelSize.w,   0, 0, \\
                 _SecondTex_TexelSize.z, _SecondTex_TexelSize.w, 0, 0, \\
@@ -2122,7 +2476,7 @@ where
             }
 
 ");
-
+reset_buffer_num();
     for ed in &(tu.0).0 {
         match ed {
             ExternalDeclaration::FunctionDefinition(fdef) => {


### PR DESCRIPTION
Some issues:

- Missing material in CRTs' inspector.
- In CRTs' inspector -> Material -> Shader pass is reverting to default after re-adding material (i.e.: buffer 1 corresponds to pass "1" in shader, buffer 2 -> pass "2", etc.)
- Materials -> Textures missing from texture slots.
- Cubemaps don't generate links.
- Images don't auto-download.