### PR TITLE
Updating iResolution to use a ratio that can be set in X+Y

### DIFF
--- a/src/glsl2hlsl/transpiler.rs
+++ b/src/glsl2hlsl/transpiler.rs
@@ -114,7 +114,7 @@ where
         "iChannel1" => "_SecondTex",
         "iChannel2" => "_ThirdTex",
         "iChannel3" => "_FourthTex",
-        "gl_FragCoord" => "(vertex_output.uv * _Resolution)",
+        "gl_FragCoord" => "(vertex_output.uv * iResolution)",
         "iMouse" => "_Mouse",
 
         //iResolution, iFrame, iChannelTime, iChannelResolution, iMouse, iDate, iSampleRate
@@ -1872,7 +1872,9 @@ where
         _FourthTex (\"iChannel3\", 2D) = \"white\" {}
         _Mouse (\"Mouse\", Vector) = (0.5, 0.5, 0.5, 0.5)
         [ToggleUI] _GammaCorrect (\"Gamma Correction\", Float) = 1
-        _Resolution (\"Resolution (Change if AA is bad)\", Range(1, 1024)) = 1",
+        _Resolution (\"Resolution (Change if AA is bad)\", Range(1, 1024)) = 1
+        _ResolutionX (\"ResolutionX\", Range(1, 10)) = 1
+        _ResolutionY (\"ResolutionY\", Range(1, 10)) = 1",        
     );
 
     // Add props
@@ -1921,12 +1923,14 @@ where
             float4 _Mouse;
             float _GammaCorrect;
             float _Resolution;
+            float _ResolutionX;
+            float _ResolutionY;            
 
             // GLSL Compatability macros
             #define glsl_mod(x,y) (((x)-(y)*floor((x)/(y))))
             #define texelFetch(ch, uv, lod) tex2Dlod(ch, float4((uv).xy * ch##_TexelSize.xy + ch##_TexelSize.xy * 0.5, 0, lod))
             #define textureLod(ch, uv, lod) tex2Dlod(ch, float4(uv, 0, lod))
-            #define iResolution float3(_Resolution, _Resolution, _Resolution)
+            #define iResolution float3(_ResolutionX, _ResolutionY, _Resolution)
             #define iFrame (floor(_Time.y / 60))
             #define iChannelTime float4(_Time.y, _Time.y, _Time.y, _Time.y)
             #define iDate float4(2020, 6, 18, 30)
@@ -1975,7 +1979,7 @@ where
                     let _ = f.write_str(get_indent().as_str());
                     let _ = f.write_fmt(format_args!("float4 {} = 0;\n", frag));
                     let _ = f.write_str(get_indent().as_str());
-                    let _ = f.write_fmt(format_args!("float2 {} = vertex_output.uv * _Resolution;\n", uv));
+                    let _ = f.write_fmt(format_args!("float2 {} = vertex_output.uv * iResolution;\n", uv));
                     for st in &fdef.statement.statement_list {
                         show_statement(f, st, true);
                     }
@@ -2024,7 +2028,8 @@ where
         _Mouse (\"Mouse\", Vector) = (0.5, 0.5, 0.5, 0.5)
         [ToggleUI] _GammaCorrect (\"Gamma Correction\", Float) = 1
         _Resolution (\"Resolution (Change if AA is bad)\", Range(1, 1024)) = 1
-
+        _ResolutionX (\"ResolutionX\", Range(1, 10)) = 1
+        _ResolutionY (\"ResolutionY\", Range(1, 10)) = 1
         [Header(Raymarching)]
         [ToggleUI] _WorldSpace (\"World Space Marching\", Float) = 0
         _Offset (\"Offset (W=Scale)\", Vector) = (0, 0, 0, 1)",
@@ -2080,6 +2085,8 @@ where
             float4 _Mouse;
             float _GammaCorrect;
             float _Resolution;
+            float _ResolutionX;
+            float _ResolutionY;                        
             float _WorldSpace;
             float4 _Offset;
 
@@ -2087,7 +2094,7 @@ where
             #define glsl_mod(x,y) (((x)-(y)*floor((x)/(y))))
             #define texelFetch(ch, uv, lod) tex2Dlod(ch, float4((uv).xy * ch##_TexelSize.xy + ch##_TexelSize.xy * 0.5, 0, lod))
             #define textureLod(ch, uv, lod) tex2Dlod(ch, float4(uv, 0, lod))
-            #define iResolution float3(_Resolution, _Resolution, _Resolution)
+            #define iResolution float3(_ResolutionX, _ResolutionY, _Resolution)
             #define iFrame (floor(_Time.y / 60))
             #define iChannelTime float4(_Time.y, _Time.y, _Time.y, _Time.y)
             #define iDate float4(2020, 6, 18, 30)
@@ -2191,7 +2198,7 @@ where
                     let _ = f.write_str(get_indent().as_str());
                     let _ = f.write_fmt(format_args!("float4 {} = 0;\n", frag));
                     let _ = f.write_str(get_indent().as_str());
-                    let _ = f.write_fmt(format_args!("float2 {} = vertex_output.uv * _Resolution;\n", uv));
+                    let _ = f.write_fmt(format_args!("float2 {} = vertex_output.uv * iResolution;\n", uv));
                     for st in &fdef.statement.statement_list {
                         show_statement(f, st, true);
                     }


### PR DESCRIPTION
I found that this method of independent X+Y Resolutions was better for getting non-squashed Shaders. I was typically using a 16:9 Quad, so setting ResolutionX to 16.0/9.0 and ResolutionY to 1.0 seemed to produce better results.